### PR TITLE
DetailViewControllerをSwiftUIのDetailViewで置き換えた。

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		0B2F33B125CEF844003BA34C /* GitHubLanguageColors.json in Resources */ = {isa = PBXBuildFile; fileRef = 0B2F33B025CEF844003BA34C /* GitHubLanguageColors.json */; };
 		0B2F33B625CEF991003BA34C /* GitHubLanguageColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F33B525CEF991003BA34C /* GitHubLanguageColors.swift */; };
 		0B2F33C225CF0234003BA34C /* UIColor.hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F33C125CF0234003BA34C /* UIColor.hex.swift */; };
+		0BB3A8FD25CF9F1B00C3A7FD /* RemoteImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3A8FC25CF9F1B00C3A7FD /* RemoteImageView.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -99,6 +100,7 @@
 		0B2F33B025CEF844003BA34C /* GitHubLanguageColors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = GitHubLanguageColors.json; sourceTree = "<group>"; };
 		0B2F33B525CEF991003BA34C /* GitHubLanguageColors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubLanguageColors.swift; sourceTree = "<group>"; };
 		0B2F33C125CF0234003BA34C /* UIColor.hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.hex.swift; sourceTree = "<group>"; };
+		0BB3A8FC25CF9F1B00C3A7FD /* RemoteImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageView.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 		0B2F32FC25CDB30E003BA34C /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				0BB3A8F525CF9EDE00C3A7FD /* Common */,
 				0B2F323F25CA95D7003BA34C /* Detail */,
 				0B2F323925CA9553003BA34C /* Search */,
 			);
@@ -285,6 +288,14 @@
 				0B2F33B525CEF991003BA34C /* GitHubLanguageColors.swift */,
 			);
 			path = Generated;
+			sourceTree = "<group>";
+		};
+		0BB3A8F525CF9EDE00C3A7FD /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				0BB3A8FC25CF9F1B00C3A7FD /* RemoteImageView.swift */,
+			);
+			path = Common;
 			sourceTree = "<group>";
 		};
 		BFD945D2244DC5E80012785A = {
@@ -490,6 +501,7 @@
 				0B2F337825CE9993003BA34C /* UIImageView+SFSymbols.swift in Sources */,
 				0B2F33AD25CEEF93003BA34C /* Language.swift in Sources */,
 				0B2F327625CA9879003BA34C /* Injectable.swift in Sources */,
+				0BB3A8FD25CF9F1B00C3A7FD /* RemoteImageView.swift in Sources */,
 				0B2F327525CA9879003BA34C /* Instantiatable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		0B2F33B625CEF991003BA34C /* GitHubLanguageColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F33B525CEF991003BA34C /* GitHubLanguageColors.swift */; };
 		0B2F33C225CF0234003BA34C /* UIColor.hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F33C125CF0234003BA34C /* UIColor.hex.swift */; };
 		0BB3A8FD25CF9F1B00C3A7FD /* RemoteImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3A8FC25CF9F1B00C3A7FD /* RemoteImageView.swift */; };
+		0BB3A90725CFA05B00C3A7FD /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB3A90625CFA05B00C3A7FD /* DetailView.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -101,6 +102,7 @@
 		0B2F33B525CEF991003BA34C /* GitHubLanguageColors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubLanguageColors.swift; sourceTree = "<group>"; };
 		0B2F33C125CF0234003BA34C /* UIColor.hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.hex.swift; sourceTree = "<group>"; };
 		0BB3A8FC25CF9F1B00C3A7FD /* RemoteImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageView.swift; sourceTree = "<group>"; };
+		0BB3A90625CFA05B00C3A7FD /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 			children = (
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				0B2F324025CA95E5003BA34C /* DetailViewController.storyboard */,
+				0BB3A90625CFA05B00C3A7FD /* DetailView.swift */,
 			);
 			path = Detail;
 			sourceTree = "<group>";
@@ -493,6 +496,7 @@
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				0B2F32C425CD5430003BA34C /* SearchViewPresenter.swift in Sources */,
+				0BB3A90725CFA05B00C3A7FD /* DetailView.swift in Sources */,
 				0B2F33C225CF0234003BA34C /* UIColor.hex.swift in Sources */,
 				0B2F32D825CD5A47003BA34C /* SearchModel.swift in Sources */,
 				0B2F331C25CDC08B003BA34C /* Owner.swift in Sources */,

--- a/iOSEngineerCodeCheck/Sources/Common/Models/Repository.swift
+++ b/iOSEngineerCodeCheck/Sources/Common/Models/Repository.swift
@@ -9,7 +9,12 @@
 import Foundation
 import UIKit
 
-struct Repository: Decodable {
+struct Repository: Decodable, Equatable {
+    
+    static func ==(lhs: Self, rhs: Self) -> Bool {
+        return lhs.id == rhs.id
+    }
+    
     let id: Int
     let name: String
     let fullName: String
@@ -19,6 +24,8 @@ struct Repository: Decodable {
     let forksCount: Int
     let openIssuesCount: Int
     let description: String?
+    let homepage: String?
+    let htmlUrl: String?
     
     let owner: Owner
     
@@ -32,14 +39,14 @@ struct Repository: Decodable {
         case forksCount = "forks_count"
         case openIssuesCount = "open_issues_count"
         case description
+        case homepage
+        case htmlUrl = "html_url"
         case owner
     }
 }
 
-extension Repository: Equatable {
-    static func ==(lhs: Self, rhs: Self) -> Bool {
-        return lhs.id == rhs.id
-    }
+extension Repository {
+    static let template = Repository(id: 0, name: "swift", fullName: "apple/swift", language: "C++", stargazersCount: 54964, watchersCount: 54964, forksCount: 8836, openIssuesCount: 309, description: "The Swift Programming Language", homepage: "https://opendev.org/openstack/swift", htmlUrl: "https://github.com/apple/swift", owner: .init(avatarUrl: "https://avatars.githubusercontent.com/u/10639145?v=4", login: "apple"))
 }
 
 extension Repository {

--- a/iOSEngineerCodeCheck/Sources/Views/Common/RemoteImageView.swift
+++ b/iOSEngineerCodeCheck/Sources/Views/Common/RemoteImageView.swift
@@ -22,11 +22,8 @@ class RemoteImage: ObservableObject {
     private func loadImage(url: URL) {
         ImagePipeline.shared.loadImage(with: url) { [weak self] result in
             guard let self = self else { return }
-            switch result {
-            case .success(let response):
+            if case let .success(response) = result {
                 self.image = response.image
-            case .failure(let error):
-                print(error.localizedDescription)
             }
         }
     }

--- a/iOSEngineerCodeCheck/Sources/Views/Common/RemoteImageView.swift
+++ b/iOSEngineerCodeCheck/Sources/Views/Common/RemoteImageView.swift
@@ -1,0 +1,48 @@
+//
+//  RemoteImageView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 戸高新也 on 2021/02/07.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import SwiftUI
+import Nuke
+
+class RemoteImage: ObservableObject {
+    @Published var image: UIImage
+
+    init(urlString: String, placeholder: UIImage) {
+        self.image = placeholder
+        guard let url = URL(string: urlString) else { return }
+        
+        loadImage(url: url)
+    }
+
+    private func loadImage(url: URL) {
+        ImagePipeline.shared.loadImage(with: url) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let response):
+                self.image = response.image
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+        }
+    }
+}
+
+struct RemoteImageView: View {
+    @ObservedObject var remoteImage: RemoteImage
+    var body: some View {
+        Image(uiImage: remoteImage.image)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+    }
+}
+
+struct RemoteImageView_Previews: PreviewProvider {
+    static var previews: some View {
+        RemoteImageView(remoteImage: RemoteImage(urlString: "https://avatars.githubusercontent.com/u/10639145?s=200&v=4", placeholder: UIImage(systemName: "applelogo")!))
+    }
+}

--- a/iOSEngineerCodeCheck/Sources/Views/Detail/DetailView.swift
+++ b/iOSEngineerCodeCheck/Sources/Views/Detail/DetailView.swift
@@ -1,0 +1,69 @@
+//
+//  DetailView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 戸高新也 on 2021/02/07.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct DetailView: View {
+    
+    let repository: Repository
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                RemoteImageView(remoteImage:
+                                    RemoteImage(urlString: repository.owner.avatarUrl,
+                                    placeholder: UIImage(systemName: "circle.fill")!))
+                    .frame(width: 60, height: 60, alignment: .center)
+                    .cornerRadius(8)
+                    Text(repository.owner.login)
+                        .font(.title)
+            }
+            
+            Text(repository.name)
+                .font(.title).bold()
+            
+            repository.description.map { Text($0) }
+            
+            HStack {
+                if let homepage = repository.homepage, let url = URL(string: homepage) {
+                    Image(systemName: "link")
+                    Button("ホームページ") {
+                        UIApplication.shared.open(url)
+                    }
+                }
+            }.padding(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
+            
+            HStack {
+                if let htmlUrl = repository.htmlUrl, let url = URL(string: htmlUrl) {
+                    Image(systemName: "link")
+                    Button("ブラウザで開く") {
+                        UIApplication.shared.open(url)
+                    }
+                }
+            }.padding(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
+            
+            HStack {
+                Image(systemName: "star")
+                Text("\(repository.stargazersCount) stars")
+                Image(systemName: "tuningfork")
+                Text("\(repository.forksCount) forks")
+            }
+        }.padding()
+        .background(Color.white)
+        .cornerRadius(8)
+        .clipped()
+        .shadow(color: .gray, radius: 4)
+        .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+    }
+}
+
+struct DetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        DetailView(repository: Repository.template)
+    }
+}

--- a/iOSEngineerCodeCheck/Sources/Views/Search/SearchViewController.storyboard
+++ b/iOSEngineerCodeCheck/Sources/Views/Search/SearchViewController.storyboard
@@ -8,7 +8,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Search View Controller-->
+        <!--Search-->
         <scene sceneID="NH6-wq-xP7">
             <objects>
                 <tableViewController id="a2E-tS-0hT" customClass="SearchViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
@@ -52,7 +52,7 @@
                             <outlet property="delegate" destination="a2E-tS-0hT" id="Vlo-4N-pbE"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Search View Controller" id="PcD-pB-apZ"/>
+                    <navigationItem key="navigationItem" title="Search" id="PcD-pB-apZ"/>
                     <connections>
                         <outlet property="searchBar" destination="PTE-Yt-BVw" id="3cQ-9Y-I8o"/>
                     </connections>

--- a/iOSEngineerCodeCheck/Sources/Views/Search/SearchViewController.swift
+++ b/iOSEngineerCodeCheck/Sources/Views/Search/SearchViewController.swift
@@ -19,7 +19,7 @@ class SearchViewController: UITableViewController, StoryboardInstantiatable, Inj
 
     @IBOutlet weak var searchBar: UISearchBar! {
         didSet {
-            searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
+            searchBar.placeholder = "リポジトリを検索"
             searchBar.delegate = self
         }
     }
@@ -36,10 +36,25 @@ class SearchViewController: UITableViewController, StoryboardInstantiatable, Inj
         setupTableView()
     }
     
+    /// - Note: To avoid scroll to top when pop viewController
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        tableView.isScrollEnabled = true
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+    
+        tableView.isScrollEnabled = false
+    }
+    
+   
+    
     private func setupTableView() {
         tableView.register(cellType: RepositoryCell.self)
         tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 98
+        tableView.estimatedRowHeight = 134
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/iOSEngineerCodeCheck/Sources/Views/Search/SearchViewController.swift
+++ b/iOSEngineerCodeCheck/Sources/Views/Search/SearchViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import APIKit
+import SwiftUI
 
 protocol SearchView: class {
     func updateTableView()
@@ -53,8 +54,8 @@ class SearchViewController: UITableViewController, StoryboardInstantiatable, Inj
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let item = presenter.repositories[indexPath.item]
-        let detailVC = DetailViewController.instantiate(with: item)
+        let repository = presenter.repositories[indexPath.item]
+        let detailVC = UIHostingController(rootView: DetailView(repository: repository))
         navigationController?.pushViewController(detailVC, animated: true)
     }
     

--- a/iOSEngineerCodeCheck/Sources/Views/Search/SearchViewController.swift
+++ b/iOSEngineerCodeCheck/Sources/Views/Search/SearchViewController.swift
@@ -49,8 +49,6 @@ class SearchViewController: UITableViewController, StoryboardInstantiatable, Inj
         tableView.isScrollEnabled = false
     }
     
-   
-    
     private func setupTableView() {
         tableView.register(cellType: RepositoryCell.self)
         tableView.rowHeight = UITableView.automaticDimension

--- a/iOSEngineerCodeCheckTests/Views/Search/SearchViewPresenterTest.swift
+++ b/iOSEngineerCodeCheckTests/Views/Search/SearchViewPresenterTest.swift
@@ -34,9 +34,9 @@ class SearchModelStub: SearchModelProtocol {
     var delegate: SearchModelDelegate?
     var sessionTask: SessionTask?
     
-    private var fetchInitialRepositoriesResponse: [String: Result<[Repository], Error>] = [:]
+    private var fetchInitialRepositoriesResponse: [String: Result<[Repository], SessionTaskError>] = [:]
     
-    func addFetchInitialRepositoriesResponse(query: String, result: Result<[Repository], Error>) {
+    func addFetchInitialRepositoriesResponse(query: String, result: Result<[Repository], SessionTaskError>) {
         self.fetchInitialRepositoriesResponse[query] = result
     }
     
@@ -57,10 +57,8 @@ class SearchModelStub: SearchModelProtocol {
     func fetchAdditionalRepositories() {}
 }
 
-extension SearchModelStub {
-    enum APIErrpr: Error {
-        case unknownError
-    }
+enum APIErrpr: Error {
+    case unknownError
 }
 
 class SearchViewPresenterTest: XCTestCase {
@@ -74,7 +72,7 @@ class SearchViewPresenterTest: XCTestCase {
                 presenter.view = spy
                 let textToSearch = "swift"
                 
-                let response: Result<[Repository], Error> = .success([.init(id: 0, name: "swift", fullName: "swift/apple", language: "c", stargazersCount: 12345, watchersCount: 12345, forksCount: 12345, openIssuesCount: 12345, description: "oss", owner: .init(avatarUrl: "https:/hogehoge", login: "apple"))])
+                let response: Result<[Repository], SessionTaskError> = .success([Repository.template])
                 
                 stub.addFetchInitialRepositoriesResponse(query: textToSearch, result: response)
                 let exp = XCTestExpectation(description: "searchButtonTappedが呼ばれた後に実行されるupdateTableViewを待つ")
@@ -94,7 +92,7 @@ class SearchViewPresenterTest: XCTestCase {
                 let presenter = SearchViewPresenter(model: stub)
                 presenter.view = spy
                 let textToSearch = "swift"
-                let response: Result<[Repository], Error> = .failure(SearchModelStub.APIErrpr.unknownError)
+                let response: Result<[Repository], SessionTaskError> = .failure(SessionTaskError.responseError(APIErrpr.unknownError))
                 
                 stub.addFetchInitialRepositoriesResponse(query: textToSearch, result: response)
                 let exp = XCTestExpectation(description: "searchButtonTappedが呼ばれた後に実行されるshowAlertを待つ")


### PR DESCRIPTION
## Issue
- yumemi-inc/ios-engineer-codecheck#8
### UIをブラッシュアップ
- DetailViewControllerをSwiftUIの DetailViewで置き換えた
### 画像
<img src="https://user-images.githubusercontent.com/41521458/107139544-42e44d80-695f-11eb-9ce6-126247546b48.png" width="320px">

### 追記
元のDetailViewControllerは残してますがUIKitでUIを作りたくなった時のために残しています。